### PR TITLE
Add Ansis JavaScript library

### DIFF
--- a/tables_libraries.tsv
+++ b/tables_libraries.tsv
@@ -1,4 +1,5 @@
 Library	Description	Date / Version Supported
+[ansis](https://github.com/webdiscus/ansis)	JavaScript library to colorize terminal with ANSI colors & styles	[2024-04-15 / 3.1.1](https://github.com/webdiscus/ansis/releases/tag/v3.1.1)
 [chalk](https://github.com/chalk)	Color library for JavaScript	[2015-02-23 / 1.0.0](https://github.com/chalk/chalk/releases/tag/v1.0.0)
 [supports-color](https://www.npmjs.com/package/supports-color)	JavaScript library to detect terminal color support
 [colorette](https://www.npmjs.com/package/colorette)	JavaScript library to color text	[2018-07-13 / 1.0.0](https://github.com/jorgebucaran/colorette/releases/tag/1.0.0)


### PR DESCRIPTION
Hello @donatj,

Tne JavaScript library [ansis](https://github.com/webdiscus/ansis) for colorise terminal outputs supports [environment variables](https://github.com/donatj/force-color.org/pull/26#cli-vars) `FORCE_COLOR` `NO_COLOR` and flags `--no-color` `--color`.

Can you please add this library to the list on force-color.org.

Thanks!