### PR TITLE
Add Sphinx

### DIFF
--- a/tables_software.tsv
+++ b/tables_software.tsv
@@ -1,10 +1,10 @@
 Software	Description	Date / Version Supported
-[jest](https://jestjs.io/jest)	JavaScript testing framework	
 [Deno](https://deno.com/)	JavaScript, TypeScript, and WebAssembly runtime	[2025-03-14 / 2.2.4](https://github.com/denoland/deno/releases/tag/v2.2.4)
 [node](https://nodejs.org/node)	JavaScript runtime	
+[Python](https://www.python.org/)	Python programming language	[2024-10-07 / 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages)
+[jest](https://jestjs.io/jest)	JavaScript testing framework	
 [Nox](https://github.com/wntrblm/nox)	Flexible test automation for Python	[2022-01-07 / 2022.1.7](https://github.com/wntrblm/nox/releases/tag/2022.1.7)
 [npm](https://www.npmjs.com/npm)	Package manager for JavaScript	
-[Python](https://www.python.org/)	Python programming language	[2024-10-07 / 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages)
 [pytest](https://docs.pytest.org)	Python testing framework	[2020-07-28 / 6.0.0](https://github.com/pytest-dev/pytest/releases/tag/6.0.0)
 [Sphinx](https://www.sphinx-doc.org/) Documentation generator  [2022-03-28 / 4.5.0](https://www.sphinx-doc.org/en/master/changes/4.5.html)
 [turbo](https://github.com/vercel/turbo)	Toolchain for frontend development in Rust	[2022-04-07 / v1.2.0](https://github.com/vercel/turbo/releases/tag/v1.2.0)

--- a/tables_software.tsv
+++ b/tables_software.tsv
@@ -1,6 +1,6 @@
 Software	Description	Date / Version Supported
-[Deno](https://deno.com/)	JavaScript, TypeScript, and WebAssembly runtime	[2025-03-14 / 2.2.4](https://github.com/denoland/deno/releases/tag/v2.2.4)
 [node](https://nodejs.org/node)	JavaScript runtime	
+[Deno](https://deno.com/)	JavaScript, TypeScript, and WebAssembly runtime	[2025-03-14 / 2.2.4](https://github.com/denoland/deno/releases/tag/v2.2.4)
 [Python](https://www.python.org/)	Python programming language	[2024-10-07 / 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages)
 [jest](https://jestjs.io/jest)	JavaScript testing framework	
 [Nox](https://github.com/wntrblm/nox)	Flexible test automation for Python	[2022-01-07 / 2022.1.7](https://github.com/wntrblm/nox/releases/tag/2022.1.7)

--- a/tables_software.tsv
+++ b/tables_software.tsv
@@ -1,9 +1,10 @@
 Software	Description	Date / Version Supported
-[node](https://nodejs.org/node)	JavaScript runtime	
+[jest](https://jestjs.io/jest)	JavaScript testing framework	
 [Deno](https://deno.com/)	JavaScript, TypeScript, and WebAssembly runtime	[2025-03-14 / 2.2.4](https://github.com/denoland/deno/releases/tag/v2.2.4)
-[Python](https://www.python.org/)	Python programming language	[2024-10-07 / 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages)
+[node](https://nodejs.org/node)	JavaScript runtime	
 [Nox](https://github.com/wntrblm/nox)	Flexible test automation for Python	[2022-01-07 / 2022.1.7](https://github.com/wntrblm/nox/releases/tag/2022.1.7)
 [npm](https://www.npmjs.com/npm)	Package manager for JavaScript	
-[jest](https://jestjs.io/jest)	JavaScript testing framework	
+[Python](https://www.python.org/)	Python programming language	[2024-10-07 / 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages)
 [pytest](https://docs.pytest.org)	Python testing framework	[2020-07-28 / 6.0.0](https://github.com/pytest-dev/pytest/releases/tag/6.0.0)
+[Sphinx](https://www.sphinx-doc.org/) Documentation generator  [2022-03-28 / 4.5.0](https://www.sphinx-doc.org/en/master/changes/4.5.html)
 [turbo](https://github.com/vercel/turbo)	Toolchain for frontend development in Rust	[2022-04-07 / v1.2.0](https://github.com/vercel/turbo/releases/tag/v1.2.0)


### PR DESCRIPTION
The Sphinx documentation generator addded support for `FORCE_COLOR` in [version 4.5](https://www.sphinx-doc.org/en/master/changes/4.5.html).

It was unclear where I should put new entries, as Deno (#55) was added as the second entry but not in alphabetical order. As such, I've sorted the entries here, but if you (@donatj) have a different order you'd prefer to maintain, please push to this branch & revert to the prior ordering.

Thank you!

A