### PR TITLE
Add table documenting alternatives

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,9 @@ export LIBRARIES
 SOFTWARE=$(npx csv-to-markdown-table --headers < tables_software.tsv)
 export SOFTWARE
 
+ALTERNATIVES=$(npx csv-to-markdown-table --headers < tables_alternatives.tsv)
+export ALTERNATIVES
+
 CONTENT="$(envsubst < index.md | npx marked --gif)"
 export CONTENT
 

--- a/index.md
+++ b/index.md
@@ -58,3 +58,7 @@ ${LIBRARIES}
 ## Software supporting `FORCE_COLOR` to force enable color support
 
 ${SOFTWARE}
+
+## Forcing colored output in software not supporting `FORCE_COLOR`
+
+${ALTERNATIVES}

--- a/tables_alternatives.tsv
+++ b/tables_alternatives.tsv
@@ -1,0 +1,2 @@
+Software	Alternative
+[pre-commit](https://pre-commit.com/)	`pre-commit --color=never` or `export PRE_COMMIT_COLOR=never` ([Docs](https://pre-commit.com/#command-line-interface), [Rejected `FORCE_COLOR` Request](https://github.com/pre-commit/pre-commit/issues/2919#issuecomment-1620753032))


### PR DESCRIPTION
Since `FORCE_COLOR` won't be accepted everywhere, it makes sense to build a common reference table on how to achieve the same effect using existing options. We also can attach rejected requests, so users wouldn't try to suggest `FORCE_COLOR` to some software again.

Similar to how `NO_COLOR` has a similar table - https://no-color.org/

Just adding the first entry in this PR to start the table.

<img width="862" height="136" alt="image" src="https://github.com/user-attachments/assets/321419b0-d429-4dea-9419-7272108c3c65" />


@donatj can you please take a look?
